### PR TITLE
Support pro sub-registy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.3.1 (2024-01-06)
+- Added `ares_util.ares.call_ares_sub_register` for getting data from sub registers described at: https://ares.gov.cz/swagger-ui/#/
+- Added `ares_util.ares.sub_register_state_transformer`
+- Added `ares_util.settings.SUB_REGISTER_MAP`
+- Modified `ares_util.ares.call_ares` to also return `sub_registers` dictionary with info about available sub registers
+
 ## 0.3.0 (2024-01-04)
 - `ares_util.ares.call_ares`
   - no longer raise `AresNoResponseError`

--- a/ares_util/settings.py
+++ b/ares_util/settings.py
@@ -5,3 +5,20 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 COMPANY_ID_LENGTH = 8
 ARES_API_URL = 'https://ares.gov.cz/'
+
+# Identifiers returned by base endpoint (/ekonomicke-subjekty/) mapped to their respective endpoints
+SUB_REGISTER_MAP = {
+    "stavZdrojeVr": "ekonomicke-subjekty-vr/",
+    "stavZdrojeRes": "ekonomicke-subjekty-res/",
+    "stavZdrojeRzp": "ekonomicke-subjekty-rzp/",
+    "stavZdrojeNrpzs": "ekonomicke-subjekty-nrpzs/",
+    "stavZdrojeRpsh": "ekonomicke-subjekty-rpsh/",
+    "stavZdrojeRcns": "ekonomicke-subjekty-rcns/",
+    "stavZdrojeSzr": "ekonomicke-subjekty-szr/",
+    "stavZdrojeDph": "ekonomicke-subjekty-dph/",
+    "stavZdrojeSd": "ekonomicke-subjekty-sd/",
+    "stavZdrojeIr": "ekonomicke-subjekty-ir/",
+    "stavZdrojeCeu": "ekonomicke-subjekty-ceu/",
+    "stavZdrojeRs": "ekonomicke-subjekty-rs/",
+    "stavZdrojeRed": "ekonomicke-subjekty-red/",
+}

--- a/tests/ares_test.py
+++ b/tests/ares_test.py
@@ -10,7 +10,7 @@ from unittest import TestCase
 import responses
 
 from ares_util import ares
-from ares_util.ares import call_ares
+from ares_util.ares import call_ares, call_ares_sub_register
 from ares_util.exceptions import AresConnectionError, AresServerError
 from ares_util.helpers import normalize_company_id_length
 from ares_util.settings import ARES_API_URL
@@ -93,3 +93,13 @@ class CallARESTestCase(TestCase):
 
         self.assertEqual(context.exception.fault_code, u'Server.Service')
         self.assertEqual(context.exception.fault_message, u'obecná chyba serverové služby')
+
+    @responses.activate
+    def test_call_sub_register(self):
+        company_id = 25853902
+
+        sub_registers = call_ares(company_id=company_id)['sub_registers']
+
+        sub_register = call_ares_sub_register(company_id=company_id, sub_registers=sub_registers, target='stavZdrojeVr')
+
+        self.assertNotEmpty(sub_register)


### PR DESCRIPTION
Po přechodu na nové API chodí v rámci základního volání ```/ekonomicke-subjekty/``` poměrně omezená data a například u naší implementace nám chyběli informace ohledně místa registrace, vložky a oddílu. Ty se nacházejí v sub-registru ```/ekonomicke-subjekty-vr/```.

Udělal jsem obecně pro všechny registry protože je možné že se to bude v budoucnu někomu hodit.